### PR TITLE
bugfix to handle falsy field values

### DIFF
--- a/src/CacheClass.js
+++ b/src/CacheClass.js
@@ -23,6 +23,8 @@ export class Cache {
       throw TypeError('input should be a string');
     // destructure the query string into an object
     const queries = destructureQueries(queryStr).queries;
+    // breaks out of function if queryStr is a mutation
+    if (!queries) return undefined;
     const responseObject = {};
     // iterate through each query in the input queries object
     for (const query in queries) {

--- a/src/CacheClass.js
+++ b/src/CacheClass.js
@@ -142,7 +142,7 @@ export class Cache {
         for (const field in fields) {
           if (readVal[field] === 'DELETED') continue;
           // for each field in the fields input query, add the corresponding value from the cache if the field is not another array of hashs
-          if (!readVal[field] && field !== '__typename') {
+          if (readVal[field] === undefined && field !== '__typename') {
             return undefined;
           } else if (typeof fields[field] !== 'object') {
             // add the typename for the type
@@ -155,6 +155,7 @@ export class Cache {
               readVal[field],
               fields[field]
             );
+            if (dataObj[field] === undefined) return undefined;
           }
         }
         // acc is an array of response object for each hash
@@ -185,6 +186,7 @@ export class Cache {
             readVal[field],
             fields[field]
           );
+          if (dataObj[field] === undefined) return undefined;
         }
       }
       return dataObj;

--- a/src/newNormalize.js
+++ b/src/newNormalize.js
@@ -195,7 +195,7 @@ function createHash(obj, output = {}) {
     //check whether current field is not an array
     if (!Array.isArray(obj[field])) {
       //check whether current field is an object
-      if (typeof obj[field] === 'object') {
+      if (typeof obj[field] === 'object' && obj[field] !== null) {
         const id =
           obj[field].id ||
           obj[field].ID ||

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -88,13 +88,14 @@ export async function ObsidianRouter<T>({
           body.variables || undefined,
           body.operationName || undefined
         );
+
         // Send database response to client //
         response.status = 200;
         response.body = result;
 
         // Normalize response and store in cache //
-        if (useCache && toNormalize) cache.write(body.query, result, false);
-
+        if (useCache && toNormalize && !result.errors)
+          cache.write(body.query, result, false);
         return;
       } catch (error) {
         response.status = 200;


### PR DESCRIPTION
fixed an issue where obsidian could not handle falsy filed values including null

EDIT: fixes an issue where cache.read can't handle a mutationStr

EDIT: fixes an issue where caching was not being bypassed on a graphQL error