### PR TITLE
Alias feature implemented for server-side caching

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,6 @@
-POSTGRES_URI=postgres://zjxjnswd:Wh7KJIyXiEy5QyhzXUMK38ykEtYH_9QZ@lallah.db.elephantsql.com:5432/zjxjnswd
+PG_PORT=5432
+PG_USER=uiikgqgj
+PG_DATABASE=uiikgqgj
+PG_PASSWORD=cSjcLEFvsuAb7Q3bc6O5p2LYbyjWlw5t
+PG_HOSTNAME=suleiman.db.elephantsql.com
 REDIS_HOST=localhost

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dump.rdb
 .DS_Store
 .env
+server.tsx
+server2.tsx

--- a/src/CacheClassBrowser.js
+++ b/src/CacheClassBrowser.js
@@ -69,19 +69,11 @@ export default class Cache {
 
   // cache read/write helper methods
   async cacheRead(hash) {
-    // console.log(
-    //   '\n\n🚀 ~ file: CacheClassBrowser.js ~ line 74 ~ Cache ~ cacheRead ~ this.storage',
-    //   this.storage
-    // );
     return this.storage[hash];
   }
 
   async cacheWrite(hash, value) {
     this.storage[hash] = value;
-    // console.log(
-    //   '\n\n🚀 ~ file: CacheClassBrowser.js ~ line 78 ~ Cache ~ cacheWrite ~ this.storage',
-    //   this.storage
-    // );
   }
   async cacheDelete(hash) {
     delete this.storage[hash];

--- a/src/CacheClassBrowser.js
+++ b/src/CacheClassBrowser.js
@@ -69,10 +69,19 @@ export default class Cache {
 
   // cache read/write helper methods
   async cacheRead(hash) {
+    // console.log(
+    //   '\n\n🚀 ~ file: CacheClassBrowser.js ~ line 74 ~ Cache ~ cacheRead ~ this.storage',
+    //   this.storage
+    // );
     return this.storage[hash];
   }
+
   async cacheWrite(hash, value) {
     this.storage[hash] = value;
+    // console.log(
+    //   '\n\n🚀 ~ file: CacheClassBrowser.js ~ line 78 ~ Cache ~ cacheWrite ~ this.storage',
+    //   this.storage
+    // );
   }
   async cacheDelete(hash) {
     delete this.storage[hash];

--- a/src/CacheClassServer.js
+++ b/src/CacheClassServer.js
@@ -44,12 +44,14 @@ export class Cache {
       if (rootQuery[queryHash]) {
         // get the hashs to populate from the existent query in the cache
         const arrayHashes = rootQuery[queryHash];
+        // Determines responseObject property labels - use alias if applicable, otherwise use name
+        const respObjProp = queries[query].alias ?? queries[query].name;
         // invoke populateAllHashes and add data objects to the response object for each input query
-        responseObject[queries[query].name] = await this.populateAllHashes(
+        responseObject[respObjProp] = await this.populateAllHashes(
           arrayHashes,
           queries[query].fields
         );
-        if (!responseObject[queries[query].name]) return undefined;
+        if (!responseObject[respObjProp]) return undefined;
 
         // no match with ROOT_QUERY return null or ...
       } else {
@@ -84,7 +86,6 @@ export class Cache {
   // cache read/write helper methods
   async cacheRead(hash) {
     // returns value from either object cache or   cache || 'DELETED' || undefined
-
     if (this.context === 'client') {
       return this.storage[hash];
     } else {
@@ -112,6 +113,7 @@ export class Cache {
     } else {
       value = JSON.stringify(value);
       await redis.setex(hash, 30, value);
+      let hashedQuery = await redis.get(hash);
     }
   }
   async cacheDelete(hash) {

--- a/src/destructure.js
+++ b/src/destructure.js
@@ -62,6 +62,7 @@ export function findQueryStrings(queryStrings) {
   }
   return result;
 }
+
 // helper function to create a queries object from an array of query strings
 export function createQueriesObj(arrayOfQueryStrings, typePropName) {
   // define a new empty result object
@@ -76,6 +77,7 @@ export function createQueriesObj(arrayOfQueryStrings, typePropName) {
     // push the finished query object into the queries/mutations array on the result object
     queriesObj[typePropName].push(queryObj);
   });
+
   return queriesObj;
 }
 // helper function that returns an object with a query string split into multiple parts
@@ -88,12 +90,35 @@ export function splitUpQueryStr(queryStr) {
   // checks to see if there are no arguments
   if (argsStartIndex === -1 || firstBraceIndex < argsStartIndex) {
     queryObj.name = queryStr.substring(0, firstBraceIndex).trim();
+    // // Checks if there is an alias
+    if (queryObj.name.includes(':')) {
+      // sets index of alias marker :
+      const aliasIndex = queryObj.name.indexOf(':');
+      // sets alias
+      queryObj.alias = queryObj.name.substring(0, aliasIndex).trim();
+      // shortens name to exclude alias
+      queryObj.name = queryObj.name
+        .substring(aliasIndex + 1, firstBraceIndex)
+        .trim();
+    }
     queryObj.arguments = '';
     queryObj.fields = queryStr.substring(firstBraceIndex);
+
     return queryObj;
   }
   // finds the query name string and assigns it
   queryObj.name = queryStr.substring(0, argsStartIndex).trim();
+  // Checks if there is an alias
+  if (queryObj.name.includes(':')) {
+    // sets index of alias marker :
+    const aliasIndex = queryObj.name.indexOf(':');
+    // sets alias
+    queryObj.alias = queryObj.name.substring(0, aliasIndex).trim();
+    // shortens name to exclude alias
+    queryObj.name = queryObj.name
+      .substring(aliasIndex + 1, firstBraceIndex)
+      .trim();
+  }
   // begin iterating through the queryString at the beginning of the arguments
   for (let i = argsStartIndex; i < queryStr.length; i += 1) {
     const char = queryStr[i];
@@ -108,6 +133,7 @@ export function splitUpQueryStr(queryStr) {
       if (argsString === '()') argsString = '';
       queryObj.arguments = argsString;
       queryObj.fields = queryStr.substring(i + 1).trim();
+
       return queryObj;
     }
   }
@@ -142,6 +168,7 @@ export function findQueryFields(fieldsStr) {
     // finding a non-whitespace character after the end of fieldname indicates the field is scalar or meta
     if (char.match(/\S/) && foundEndOfFieldName) {
       fieldsObj[fieldCache] = fieldCache === '__typename' ? 'meta' : 'scalar';
+
       fieldCache = '';
       foundEndOfFieldName = false;
     }
@@ -150,6 +177,7 @@ export function findQueryFields(fieldsStr) {
     // adds current non-whitespace character in fieldCache
     if (char.match(/\S/)) fieldCache += char;
   }
+
   return fieldsObj;
 }
 

--- a/src/insertTypenames.js
+++ b/src/insertTypenames.js
@@ -1,5 +1,9 @@
 // this function will insert __typename meta fields into a querystring
 export function insertTypenames(queryOperationStr) {
+  console.log(
+    '\n\n🚀 ~ file: insertTypenames.js ~ line 3 ~ insertTypenames ~ queryOperationStr',
+    queryOperationStr
+  );
   let newQueryStr = '';
   // removes extra whitespace
   const queryStr = queryOperationStr.replace(/\s\s+/g, ' ').trim();
@@ -30,10 +34,19 @@ export function insertTypenames(queryOperationStr) {
     // adds current character to newQueryString
     newQueryStr += char;
   }
+  console.log(
+    '\n\n🚀 ~ file: insertTypenames.js ~ line 36 ~ insertTypenames ~ newQueryStr',
+    newQueryStr
+  );
   return newQueryStr;
 }
+
 // helper function to add typenames to fieldsStr where needed
 export function addTypenamesToFieldsStr(fieldsStr) {
+  console.log(
+    '\n\n🚀 ~ file: insertTypenames.js ~ line 40 ~ addTypenamesToFieldsStr ~ fieldsStr',
+    fieldsStr
+  );
   let newFieldsStr = fieldsStr;
   let currentOpenBrace = 0;
   let isAnotherOpenBrace = true;
@@ -60,8 +73,13 @@ export function addTypenamesToFieldsStr(fieldsStr) {
     }
     currentOpenBrace = nextOpenBrace;
   }
+  console.log(
+    '\n\n🚀 ~ file: insertTypenames.js ~ line 69 ~ addTypenamesToFieldsStr ~ newFieldsStr',
+    newFieldsStr
+  );
   return newFieldsStr;
 }
+
 // helper function to find the partner closing brace
 export function findClosingBrace(str, index) {
   let bracePairs = 0;

--- a/src/insertTypenames.js
+++ b/src/insertTypenames.js
@@ -1,9 +1,5 @@
 // this function will insert __typename meta fields into a querystring
 export function insertTypenames(queryOperationStr) {
-  console.log(
-    '\n\n🚀 ~ file: insertTypenames.js ~ line 3 ~ insertTypenames ~ queryOperationStr',
-    queryOperationStr
-  );
   let newQueryStr = '';
   // removes extra whitespace
   const queryStr = queryOperationStr.replace(/\s\s+/g, ' ').trim();
@@ -34,19 +30,11 @@ export function insertTypenames(queryOperationStr) {
     // adds current character to newQueryString
     newQueryStr += char;
   }
-  console.log(
-    '\n\n🚀 ~ file: insertTypenames.js ~ line 36 ~ insertTypenames ~ newQueryStr',
-    newQueryStr
-  );
   return newQueryStr;
 }
 
 // helper function to add typenames to fieldsStr where needed
 export function addTypenamesToFieldsStr(fieldsStr) {
-  console.log(
-    '\n\n🚀 ~ file: insertTypenames.js ~ line 40 ~ addTypenamesToFieldsStr ~ fieldsStr',
-    fieldsStr
-  );
   let newFieldsStr = fieldsStr;
   let currentOpenBrace = 0;
   let isAnotherOpenBrace = true;
@@ -73,10 +61,6 @@ export function addTypenamesToFieldsStr(fieldsStr) {
     }
     currentOpenBrace = nextOpenBrace;
   }
-  console.log(
-    '\n\n🚀 ~ file: insertTypenames.js ~ line 69 ~ addTypenamesToFieldsStr ~ newFieldsStr',
-    newFieldsStr
-  );
   return newFieldsStr;
 }
 

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -81,21 +81,22 @@ export default function normalizeResult(queryObj, resultObj, deleteFlag) {
       }
     }
   }
-
   return result;
 }
 
-// creates the hashes for query requests and stores the reference has that will be stored in result
+// creates the hashes for query requests and stores the reference hash that will be stored in result
 function createRootQuery(queryObjArr, resultObj) {
   const output = {};
   queryObjArr.forEach((query) => {
+    // if query has an alias declare it
+    const alias = query.alias ?? null;
     const name = query.name;
     const args = query.arguments;
     const queryHash = name + args;
-
+    const result = resultObj.data[alias] ?? resultObj.data[name];
     // iterate thru the array of current query response
     // and store the hash of that response in an array
-    const result = resultObj.data[name];
+
     if (Array.isArray(result)) {
       const arrOfHashes = [];
       result.forEach((obj) => {

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -63,7 +63,7 @@ export async function ObsidianRouter<T>({
         if (useCache) {
           // Send query off to be destructured and found in Redis if possible //
           const obsidianReturn = await cache.read(body.query);
-         
+          console.log("retrieved from cache", obsidianReturn);
           if (obsidianReturn) {
             response.status = 200;
             response.body = obsidianReturn;

--- a/test_files/rhum_test_files/destructure_test.ts
+++ b/test_files/rhum_test_files/destructure_test.ts
@@ -23,7 +23,9 @@ Rhum.testPlan('destructure.ts', () => {
       Rhum.asserts.assertEquals(test.createQueriesObjResultsData, results);
     });
     Rhum.testCase('findQueryFields test', () => {
+      console.log(test.findQueryFieldsTestData);
       const results = findQueryFields(test.findQueryFieldsTestData);
+      console.log(results);
       Rhum.asserts.assertEquals(test.findQueryFieldsResultData, results);
     });
     Rhum.testCase('findClosingBrace test', () => {
@@ -46,6 +48,13 @@ Rhum.testPlan('destructure.ts', () => {
     Rhum.testCase('destructure multi query - input / non input', () => {
       const result = destructureQueries(test.ALL_ACTION_MOVIES_AND_ALL_ACTORS);
       Rhum.asserts.assertEquals(test.allActionActorsTestResult, result);
+    });
+  });
+
+  Rhum.testSuite('destructure alias query tests', () => {
+    Rhum.testCase('destructure multi alias query - input / non input', () => {
+      const result = destructureQueries(test.newAliasTestQuery);
+      Rhum.asserts.assertEquals(test.newAliasTestResult, result);
     });
   });
 });

--- a/test_files/rhum_test_files/insertTypenames_test.ts
+++ b/test_files/rhum_test_files/insertTypenames_test.ts
@@ -56,5 +56,15 @@ Rhum.testPlan('insertTypenames.js', () => {
       }
     );
   });
+
+  Rhum.testSuite('insertTypenames()', () => {
+    Rhum.testCase(
+      'should add __typenames meta field to graphql alias query',
+      () => {
+        const result = insertTypenames(test.newAliasTestQuery);
+        Rhum.asserts.assertEquals(result, test.newAliasTestResult);
+      }
+    );
+  });
 });
 Rhum.run();

--- a/test_files/rhum_test_files/normalize_test.ts
+++ b/test_files/rhum_test_files/normalize_test.ts
@@ -12,6 +12,15 @@ Rhum.testPlan('normalize.ts', () => {
       }
     );
   });
+  Rhum.testSuite('normalizeAliasTestSuite', () => {
+    Rhum.testCase(
+      'expected result to equal object with ROOT_QUERY and hash:value pairs',
+      async () => {
+        const result = normalizeResult(test.aliasTestQueryObj, test.aliasTestResult);
+        Rhum.asserts.assertEquals(result, test.aliasTestRootHash);
+      }
+    );
+  });
 });
 
 Rhum.run();

--- a/test_files/rhum_test_files/writeCache_test.ts
+++ b/test_files/rhum_test_files/writeCache_test.ts
@@ -9,6 +9,7 @@
  */
 
 import Cache from '../../src/CacheClassBrowser.js';
+import {Cache as CacheServer} from '../../src/CacheClassServer.js';
 import { Rhum } from 'https://deno.land/x/rhum@v1.1.4/mod.ts';
 import { test } from '../test_variables/writeCache_variables.ts';
 
@@ -38,6 +39,15 @@ Rhum.testPlan('write method on Cache class', () => {
         Rhum.asserts.assertEquals(test.originalCache, cache.storage);
       }
     );
+    // Rhum.testCase(
+    //   'alias test case',
+    //   async () => {   
+    //     const cache = new CacheServer(test.originalCache);
+    //     await cache.write(test.aliasQuery, test.aliasResponse);
+    //     await console.log(cache.storage);
+    //     Rhum.asserts.assertEquals(cache.storage, test.originalCache);
+    //   }
+    // );
   });
 });
 Rhum.run();

--- a/test_files/test_variables/destructure_variables.ts
+++ b/test_files/test_variables/destructure_variables.ts
@@ -47,7 +47,7 @@ export const test = {
         }
       }
     }
-    }
+    
       `,
 
   allActorsTestResult: {
@@ -218,4 +218,70 @@ export const test = {
   }`,
 
   findClosingBraceResultData: 90,
+
+  findTwoActorsAlias: `
+  query TwoActors {
+    harrisonActor: actors(id: 00) {
+            firstName
+        lastName
+        films {
+          __typename
+          id
+          title
+        }
+    }
+    hammelActor: actors(id: 01) {
+            firstName
+        lastName
+        films {
+          __typename
+          id
+          title
+        }
+    }
+  }
+  `,
+  findTwoActorsAliasTestResult: {
+    queries: [
+      {
+        name: "actors",
+        alias: "harrisonActor",
+        arguments: "(id:00)",
+        fields: { firstName: "scalar", lastName: "scalar", films: { __typename: 'meta', id: 'scalar', title: 'scalar' } }
+      },
+      {
+        name: "actors",
+        alias: "hammelActor",
+        arguments: "(id:01)",
+        fields: { firstName: "scalar", lastName: "scalar", films: { __typename: 'meta', id: 'scalar', title: 'scalar' } }
+      }
+    ]
+  },
+
+  newAliasTestQuery: `
+  query twoHeros {
+    empireHero: hero(episode: EMPIRE) {
+      name
+    }
+    jediHero: hero(episode: JEDI) {
+      name
+    }
+  }`,
+
+  newAliasTestResult:{
+    queries: [
+      {
+        name: "hero",
+        alias: "empireHero",
+        arguments: "(episode:EMPIRE)",
+        fields: { name: "scalar" }
+      },
+      {
+        name: "hero",
+        alias: "jediHero",
+        arguments: "(episode:JEDI)",
+        fields: { name: "scalar" }
+      }
+    ]
+  }
 };

--- a/test_files/test_variables/insertTypenames_variables.ts
+++ b/test_files/test_variables/insertTypenames_variables.ts
@@ -71,4 +71,16 @@ export const test = {
     '{ __typename id title genre actors { id firstName lastName } }',
   fieldsStrOutput:
     '{ __typename id title genre actors { __typename  id firstName lastName } }',
+
+  newAliasTestQuery: `
+    query twoHeros {
+      empireHero: hero(episode: EMPIRE) {
+        name
+      }
+      jediHero: hero(episode: JEDI) {
+        name
+      }
+    }`,
+
+  newAliasTestResult: `query twoHeros { empireHero: hero(episode: EMPIRE) { __typename  name } jediHero: hero(episode: JEDI) { __typename  name } }`,
 };

--- a/test_files/test_variables/normalize_variables.ts
+++ b/test_files/test_variables/normalize_variables.ts
@@ -161,8 +161,8 @@ export const test = {
   },
   resultObj1: {
     ROOT_QUERY: {
-      'movies(input:{genre:ACTION})': ['Movie~1', 'Movie~4'],
-      actors: ['Actor~1', 'Actor~2', 'Actor~3', 'Actor~4', 'Actor~5'],
+      'movies(input:{genre:ACTION})': ['Movie~1', 'Movie~4'],//"hero(episode:EMPIRE)": ["Hero~1"]              OR      /"hero": ["Hero~1", "Hero~2"]  
+      actors: ['Actor~1', 'Actor~2', 'Actor~3', 'Actor~4', 'Actor~5'],//"hero(episode:JEDI)": ["Hero~2"]
     },
     'Movie~1': {
       id: '1',
@@ -305,5 +305,57 @@ export const test = {
       firstName: 'Gary',
       favHobby: 'climbing',
     },
+  },
+  aliasTestQueryObj:{
+    queries: [
+      {
+        __typename: 'meta',
+        name: 'hero',
+        alias: 'empireHero',
+        arguments: '(episode:EMPIRE)',
+        fields: { 
+          __typename: 'meta',
+          name: 'scalar', 
+          id: 'scalar'}
+      },
+      {
+        __typename: 'meta',
+        name: 'hero',
+        alias: 'jediHero',
+        arguments: '(episode:JEDI)',
+        fields: { 
+          __typename: 'meta',
+          name: 'scalar', 
+          id: 'scalar'}
+      }
+    ]
+  },
+  aliasTestResult:{
+    data: {
+      empireHero: {
+        __typename: 'Hero',
+        id:'1',
+        name: 'Luke Skywalker'
+      },
+      jediHero: {
+        __typename: 'Hero',
+        id:'2',
+        name: "R2-D2",
+      }
+    }
+  },
+  aliasTestRootHash: {
+    "Hero~1": {
+      id: "1",
+      name: "Luke Skywalker",
+    },
+    "Hero~2": {
+      id: "2",
+      name: "R2-D2",
+    },
+    ROOT_QUERY: {
+      "hero(episode:EMPIRE)": "Hero~1",
+      "hero(episode:JEDI)": "Hero~2",
+    }
   },
 };

--- a/test_files/test_variables/writeCache_variables.ts
+++ b/test_files/test_variables/writeCache_variables.ts
@@ -189,4 +189,33 @@ export const test = {
       films: ['Movie~1'],
     },
   },
+  aliasQuery: `
+    query twoHeros {
+    jediHero: getHero(episode: "jedi") {
+          __typename
+          id
+          name
+   }
+      empireHero: getHero(episode: "empire") {
+          __typename
+          id
+          name
+      }
+    }
+  `,
+  aliasResponse: 
+  {
+    "data": {
+        "jediHero": {
+            "__typename": "Hero",
+            "id": 2,
+            "name": "R2-D2",
+        },
+        "empireHero": {
+            "__typename": "Hero",
+            "id": 1,
+            "name": "Luke Skywalker",
+        }
+    }
+},
 };


### PR DESCRIPTION
# Checklist

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

# Related Issue

Alias feature in graphql was not implemented in Obsidian server-side caching

# Solution

Aliases are extracted from the query string in the destructure file.
If applicable the alias is utilized in the hashing functionality of the normalize file.
The CacheClassServer file will store and recall data based on aliases / names as applicable.

# Additional Info

Currently queries must contain __typename. It is still unclear whether this will be completely handled by the browser wrapper, or should be implemented on the backend.
