### PR TITLE
Added alias functionality for client side caching

### DIFF
--- a/test_files/rhum_test_files/readCache_test.ts
+++ b/test_files/rhum_test_files/readCache_test.ts
@@ -48,6 +48,16 @@ Rhum.testPlan('read method on Cache class', () => {
         Rhum.asserts.assertEquals(result, test.multipleQueriesResObj);
       }
     );
+    Rhum.testCase(
+      "should accept alias queries",
+      async () => {
+        const cache = new Cache(test.aliasCache);
+        // await console.log('cache', cache)
+        const result = await cache.read(test.aliasQueryString);
+        // await console.log('result', result)
+        Rhum.asserts.assertEquals(result, test.aliasResObj);
+      }
+    );
   });
 
   Rhum.testSuite('populateAllHashes()', () => {

--- a/test_files/test_variables/readCache_variables.ts
+++ b/test_files/test_variables/readCache_variables.ts
@@ -172,28 +172,29 @@ export const test = {
   `,
   aliasQueryString: `
 {
-  empireHero: getHero(episode: "empire") {
-      __typename
-    name
-    id
-  }
   jediHero: getHero(episode: "jedi") {
       __typename
       id
 name
-}
+}  empireHero: getHero(episode: "empire") {
+      __typename
+    name
+    id
+  }
+
 }`,
 aliasResObj:{
   data: {
       empireHero: {
           __typename: "Hero",
+          id: 1,
           name: "Luke Skywalker",
-          id: 1
+
       },
       jediHero: {
           __typename: "Hero",
           id: 2,
-          name: "R2-D2"
+          name: "R2-D2",
       }
   }
 },

--- a/test_files/test_variables/readCache_variables.ts
+++ b/test_files/test_variables/readCache_variables.ts
@@ -170,4 +170,46 @@ export const test = {
    }
   }
   `,
+  aliasQueryString: `
+{
+  empireHero: getHero(episode: "empire") {
+      __typename
+    name
+    id
+  }
+  jediHero: getHero(episode: "jedi") {
+      __typename
+      id
+name
+}
+}`,
+aliasResObj:{
+  data: {
+      empireHero: {
+          __typename: "Hero",
+          name: "Luke Skywalker",
+          id: 1
+      },
+      jediHero: {
+          __typename: "Hero",
+          id: 2,
+          name: "R2-D2"
+      }
+  }
+},
+  aliasCache: {
+    ROOT_QUERY: {
+      'getHero(episode:"empire")': "Hero~1",
+      'getHero(episode:"jedi")': "Hero~2",
+    },
+    ROOT_MUTATION: {},
+    "Hero~1": {
+      id: 1,
+      name: "Luke Skywalker",
+    },
+    "Hero~2": {
+      id: 2,
+      name: "R2-D2",
+    },
+  },
 };


### PR DESCRIPTION
# Checklist

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

# Related Issue

-Alias functionality was not available for client side caching 

# Solution

- Implemented alias recognition with in the CacheClassBrowser.js file as well as a unit test for functionality.

# Additional Info

N/A
