### PR TITLE
Refactor normalize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dump.rdb
 .env
 server.tsx
 server2.tsx
+sampleServer.tsx

--- a/src/CacheClassBrowser.js
+++ b/src/CacheClassBrowser.js
@@ -3,10 +3,10 @@ import destructureQueries from './destructure.js';
 
 export default class Cache {
   constructor(
-      initialCache = {
+    initialCache = {
       ROOT_QUERY: {},
       ROOT_MUTATION: {},
-     }
+    }
   ) {
     this.storage = initialCache;
     this.context = 'client';
@@ -44,9 +44,7 @@ export default class Cache {
         return undefined;
       }
     }
-    return {
-      data: responseObject
-    };
+    return { data: responseObject };
   }
 
   async write(queryStr, respObj, deleteFlag) {
@@ -90,54 +88,65 @@ export default class Cache {
   // go through root queries, remove all instances of bad hashes, add remaining hashes into goodHashes set
   rootQueryCleaner(badHashes) {
     const goodHashes = new Set();
-      const rootQuery = this.storage['ROOT_QUERY'];
-      for (let key in rootQuery) {
-        if (Array.isArray(rootQuery[key])) {
-          rootQuery[key] = rootQuery[key].filter(x => !badHashes.has(x));
-          if (rootQuery[key].length === 0) delete rootQuery[key];
-          for (let el of rootQuery[key]) goodHashes.add(el);
-        } else (badHashes.has(rootQuery[key])) ? delete rootQuery[key] : goodHashes.add(rootQuery[key]);
-      }
-      return goodHashes;
+    const rootQuery = this.storage['ROOT_QUERY'];
+    for (let key in rootQuery) {
+      if (Array.isArray(rootQuery[key])) {
+        rootQuery[key] = rootQuery[key].filter((x) => !badHashes.has(x));
+        if (rootQuery[key].length === 0) delete rootQuery[key];
+        for (let el of rootQuery[key]) goodHashes.add(el);
+      } else
+        badHashes.has(rootQuery[key])
+          ? delete rootQuery[key]
+          : goodHashes.add(rootQuery[key]);
     }
+    return goodHashes;
+  }
 
   // Go through the cache, check good hashes for any nested hashes and add them to goodHashes set
   getGoodHashes(badHashes, goodHashes) {
-      for (let key in this.storage) {
-        if (key === 'ROOT_QUERY' || key === 'ROOT_MUTATION') continue;
-        for (let i in this.storage[key]) {
-          if (Array.isArray(this.storage[key][i])) {
-            for (let el of this.storage[key][i]) {
-              if (el.includes('~') && !badHashes.has(el)) {
-                goodHashes.add(el);
-              }
+    for (let key in this.storage) {
+      if (key === 'ROOT_QUERY' || key === 'ROOT_MUTATION') continue;
+      for (let i in this.storage[key]) {
+        if (Array.isArray(this.storage[key][i])) {
+          for (let el of this.storage[key][i]) {
+            if (el.includes('~') && !badHashes.has(el)) {
+              goodHashes.add(el);
             }
-          } else if (typeof this.storage[key][i] === 'string') {
-            if (this.storage[key][i].includes('~') && !badHashes.has(this.storage[key][i])) {
-              goodHashes.add(this.storage[key][i]);
-            }
+          }
+        } else if (typeof this.storage[key][i] === 'string') {
+          if (
+            this.storage[key][i].includes('~') &&
+            !badHashes.has(this.storage[key][i])
+          ) {
+            goodHashes.add(this.storage[key][i]);
           }
         }
       }
-      return goodHashes;
     }
+    return goodHashes;
+  }
 
   // Remove inaccessible hashes by checking if they are in goodhashes set or not
   removeInaccessibleHashes(badHashes, goodHashes) {
-      for (let key in this.storage) {
-        if (key === 'ROOT_QUERY' || key === 'ROOT_MUTATION') continue;
-        if (!goodHashes.has(key)) delete this.storage[key];
-        for (let i in this.storage[key]) {
-          if (Array.isArray(this.storage[key][i])) {
-            this.storage[key][i] = this.storage[key][i].filter(x => !badHashes.has(x));
-          } else if (typeof this.storage[key][i] === 'string') {
-            if (this.storage[key][i].includes('~') && badHashes.has(this.storage[key][i])) {
-              delete this.storage[key][i];
-            }
+    for (let key in this.storage) {
+      if (key === 'ROOT_QUERY' || key === 'ROOT_MUTATION') continue;
+      if (!goodHashes.has(key)) delete this.storage[key];
+      for (let i in this.storage[key]) {
+        if (Array.isArray(this.storage[key][i])) {
+          this.storage[key][i] = this.storage[key][i].filter(
+            (x) => !badHashes.has(x)
+          );
+        } else if (typeof this.storage[key][i] === 'string') {
+          if (
+            this.storage[key][i].includes('~') &&
+            badHashes.has(this.storage[key][i])
+          ) {
+            delete this.storage[key][i];
           }
         }
       }
     }
+  }
 
   // cache read/write helper methods
   async cacheRead(hash) {
@@ -155,7 +164,7 @@ export default class Cache {
   async cacheClear() {
     this.storage = {
       ROOT_QUERY: {},
-      ROOT_MUTATION: {}
+      ROOT_MUTATION: {},
     };
   }
 
@@ -173,9 +182,7 @@ export default class Cache {
   readWholeQuery(queryStr) {
     const hash = queryStr.replace(/\s/g, '');
     const root = this.cacheRead('ROOT_QUERY');
-    if (root[hash]) return {
-      data: root[hash]
-    };
+    if (root[hash]) return { data: root[hash] };
     return undefined;
   }
 
@@ -189,6 +196,8 @@ export default class Cache {
       return allHashesFromQuery.reduce(async (acc, hash) => {
         // for each hash from the input query, build the response object
         const readVal = await this.cacheRead(hash);
+        // return undefine if hash has been garbage collected
+        if (readVal === undefined) return undefined;
         if (readVal === 'DELETED') return acc;
         const dataObj = {};
         for (const field in fields) {
@@ -196,8 +205,7 @@ export default class Cache {
           // for each field in the fields input query, add the corresponding value from the cache if the field is not another array of hashs
           if (readVal[field] === undefined && field !== '__typename') {
             return undefined;
-          }
-          if (typeof fields[field] !== 'object') {
+          } else if (typeof fields[field] !== 'object') {
             // add the typename for the type
             if (field === '__typename') {
               dataObj[field] = typeName;
@@ -211,10 +219,14 @@ export default class Cache {
             if (dataObj[field] === undefined) return undefined;
           }
         }
-        // acc is an array of response object for each hash
-        const resolvedProm = await Promise.resolve(acc);
-        resolvedProm.push(dataObj);
-        return resolvedProm;
+        // acc is an array within a Response object for each hash
+        try {
+          const resolvedProm = await Promise.resolve(acc);
+          resolvedProm.push(dataObj);
+          return resolvedProm;
+        } catch (error) {
+          return undefined;
+        }
       }, []);
     }
     // Case where allHashesFromQuery has only one hash and is not an array but a single string
@@ -229,8 +241,7 @@ export default class Cache {
         if (readVal[field] === 'DELETED') continue;
         if (!readVal[field] && field !== '__typename') {
           return undefined;
-        }
-        if (typeof fields[field] !== 'object') {
+        } else if (typeof fields[field] !== 'object') {
           // add the typename for the type
           if (field === '__typename') {
             dataObj[field] = typeName;

--- a/src/CacheClassServer.js
+++ b/src/CacheClassServer.js
@@ -197,32 +197,5 @@ export class Cache {
         }
       }, []);
     }
-    // Case where allHashesFromQuery has only one hash and is not an array but a single string
-    const hash = allHashesFromQuery;
-    const readVal = await this.cacheRead(hash);
-    if (readVal !== 'DELETED') {
-      // include the typename for each hash
-      const hyphenIdx = hash.indexOf('~');
-      const typeName = hash.slice(0, hyphenIdx);
-      const dataObj = {};
-      for (const field in fields) {
-        if (readVal[field] === 'DELETED') continue;
-        if (!readVal[field] && field !== '__typename') {
-          return undefined;
-        } else if (typeof fields[field] !== 'object') {
-          // add the typename for the type
-          if (field === '__typename') {
-            dataObj[field] = typeName;
-          } else dataObj[field] = readVal[field];
-        } else {
-          dataObj[field] = await this.populateAllHashes(
-            readVal[field],
-            fields[field]
-          );
-          if (dataObj[field] === undefined) return undefined;
-        }
-      }
-      return dataObj;
-    }
   }
 }

--- a/src/CacheClassServer.js
+++ b/src/CacheClassServer.js
@@ -28,9 +28,9 @@ export class Cache {
 
   // set cache configurations
   async configSet(parameter, value) {
-    return await redis.configSet(parameter, value)
+    return await redis.configSet(parameter, value);
   }
-  
+
   // Main functionality methods
   async read(queryStr) {
     if (typeof queryStr !== 'string')

--- a/src/CacheClassServer.js
+++ b/src/CacheClassServer.js
@@ -156,46 +156,44 @@ export class Cache {
 
   // specialized helper methods
   async populateAllHashes(allHashesFromQuery, fields) {
-    if (Array.isArray(allHashesFromQuery)) {
-      // include the hashname for each hash
-      if (!allHashesFromQuery.length) return [];
-      const hyphenIdx = allHashesFromQuery[0].indexOf('~');
-      const typeName = allHashesFromQuery[0].slice(0, hyphenIdx);
-      return allHashesFromQuery.reduce(async (acc, hash) => {
-        // for each hash from the input query, build the response object
-        const readVal = await this.cacheRead(hash);
-        // return undefine if hash has been garbage collected
-        if (readVal === undefined) return undefined;
-        if (readVal === 'DELETED') return acc;
-        const dataObj = {};
-        for (const field in fields) {
-          if (readVal[field] === 'DELETED') continue;
-          // for each field in the fields input query, add the corresponding value from the cache if the field is not another array of hashs
-          if (readVal[field] === undefined && field !== '__typename') {
-            return undefined;
-          } else if (typeof fields[field] !== 'object') {
-            // add the typename for the type
-            if (field === '__typename') {
-              dataObj[field] = typeName;
-            } else dataObj[field] = readVal[field];
-          } else {
-            // case where the field from the input query is an array of hashes, recursively invoke populateAllHashes
-            dataObj[field] = await this.populateAllHashes(
-              readVal[field],
-              fields[field]
-            );
-            if (dataObj[field] === undefined) return undefined;
-          }
-        }
-        // acc is an array within a Response object for each hash
-        try {
-          const resolvedProm = await Promise.resolve(acc);
-          resolvedProm.push(dataObj);
-          return resolvedProm;
-        } catch (error) {
+    // include the hashname for each hash
+    if (!allHashesFromQuery.length) return [];
+    const hyphenIdx = allHashesFromQuery[0].indexOf('~');
+    const typeName = allHashesFromQuery[0].slice(0, hyphenIdx);
+    return allHashesFromQuery.reduce(async (acc, hash) => {
+      // for each hash from the input query, build the response object
+      const readVal = await this.cacheRead(hash);
+      // return undefine if hash has been garbage collected
+      if (readVal === undefined) return undefined;
+      if (readVal === 'DELETED') return acc;
+      const dataObj = {};
+      for (const field in fields) {
+        if (readVal[field] === 'DELETED') continue;
+        // for each field in the fields input query, add the corresponding value from the cache if the field is not another array of hashs
+        if (readVal[field] === undefined && field !== '__typename') {
           return undefined;
+        } else if (typeof fields[field] !== 'object') {
+          // add the typename for the type
+          if (field === '__typename') {
+            dataObj[field] = typeName;
+          } else dataObj[field] = readVal[field];
+        } else {
+          // case where the field from the input query is an array of hashes, recursively invoke populateAllHashes
+          dataObj[field] = await this.populateAllHashes(
+            readVal[field],
+            fields[field]
+          );
+          if (dataObj[field] === undefined) return undefined;
         }
-      }, []);
-    }
+      }
+      // acc is an array within a Response object for each hash
+      try {
+        const resolvedProm = await Promise.resolve(acc);
+        resolvedProm.push(dataObj);
+        return resolvedProm;
+      } catch (error) {
+        return undefined;
+      }
+    }, []);
   }
 }

--- a/src/CacheClassServer.js
+++ b/src/CacheClassServer.js
@@ -76,7 +76,6 @@ export class Cache {
         await this.cacheWrite(hash, resFromNormalize[hash]);
       }
     }
-    return;
   }
 
   // cache read/write helper methods
@@ -138,16 +137,16 @@ export class Cache {
   }
 
   writeWholeQuery(queryStr, respObj) {
-    let hash = queryStr.replace(/\s/g, '');
+    const hash = queryStr.replace(/\s/g, '');
     this.cacheWrite(ROOT_QUERY[hash], respObj);
     return respObj;
   }
 
   readWholeQuery(queryStr) {
-    let hash = queryStr.replace(/\s/g, '');
+    const hash = queryStr.replace(/\s/g, '');
     const root = this.cacheRead('ROOT_QUERY');
     if (root[hash]) return { data: root[hash] };
-    else return undefined;
+    return undefined;
   }
 
   // specialized helper methods

--- a/src/CacheClassServer.js
+++ b/src/CacheClassServer.js
@@ -1,7 +1,7 @@
 import normalizeResult from './normalize.js';
 import destructureQueries from './destructure.js';
 import 'https://deno.land/x/dotenv/load.ts';
-import { connect } from 'https://denopkg.com/keroxp/deno-redis/mod.ts';
+import { connect } from 'https://deno.land/x/redis/mod.ts';
 
 let redis;
 const context = window.Deno ? 'server' : 'client';
@@ -26,6 +26,11 @@ export class Cache {
     this.context = window.Deno ? 'server' : 'client';
   }
 
+  // set cache configurations
+  async configSet(parameter, value) {
+    return await redis.configSet(parameter, value)
+  }
+  
   // Main functionality methods
   async read(queryStr) {
     if (typeof queryStr !== 'string')

--- a/src/lfuBrowserCache.js
+++ b/src/lfuBrowserCache.js
@@ -197,54 +197,20 @@ LFUCache.prototype.populateAllHashes = async function (
   allHashesFromQuery,
   fields
 ) {
-  if (Array.isArray(allHashesFromQuery)) {
-    // include the hashname for each hash
-    if (!allHashesFromQuery.length) return [];
-    const hyphenIdx = allHashesFromQuery[0].indexOf('~');
-    const typeName = allHashesFromQuery[0].slice(0, hyphenIdx);
-    return allHashesFromQuery.reduce(async (acc, hash) => {
-      // for each hash from the input query, build the response object
-      const readVal = await this.get(hash);
-      if (readVal === 'DELETED') return acc;
-      if (!readVal) return undefined;
-      const dataObj = {};
-      for (const field in fields) {
-        if (readVal[field] === 'DELETED') continue;
-        // for each field in the fields input query, add the corresponding value from the cache if the field is not another array of hashs
-        if (readVal[field] === undefined && field !== '__typename') {
-          return undefined;
-        }
-        if (typeof fields[field] !== 'object') {
-          // add the typename for the type
-          if (field === '__typename') {
-            dataObj[field] = typeName;
-          } else dataObj[field] = readVal[field];
-        } else {
-          // case where the field from the input query is an array of hashes, recursively invoke populateAllHashes
-          dataObj[field] = await this.populateAllHashes(
-            readVal[field],
-            fields[field]
-          );
-          if (dataObj[field] === undefined) return undefined;
-        }
-      }
-      // acc is an array of response object for each hash
-      const resolvedProm = await Promise.resolve(acc);
-      resolvedProm.push(dataObj);
-      return resolvedProm;
-    }, []);
-  }
-  // Case where allHashesFromQuery has only one hash and is not an array but a single string
-  const hash = allHashesFromQuery;
-  const readVal = await this.get(hash);
-  if (readVal !== 'DELETED') {
-    // include the typename for each hash
-    const hyphenIdx = hash.indexOf('~');
-    const typeName = hash.slice(0, hyphenIdx);
+  // include the hashname for each hash
+  if (!allHashesFromQuery.length) return [];
+  const hyphenIdx = allHashesFromQuery[0].indexOf('~');
+  const typeName = allHashesFromQuery[0].slice(0, hyphenIdx);
+  return allHashesFromQuery.reduce(async (acc, hash) => {
+    // for each hash from the input query, build the response object
+    const readVal = await this.get(hash);
+    if (readVal === 'DELETED') return acc;
+    if (!readVal) return undefined;
     const dataObj = {};
     for (const field in fields) {
       if (readVal[field] === 'DELETED') continue;
-      if (!readVal[field] && field !== '__typename') {
+      // for each field in the fields input query, add the corresponding value from the cache if the field is not another array of hashs
+      if (readVal[field] === undefined && field !== '__typename') {
         return undefined;
       }
       if (typeof fields[field] !== 'object') {
@@ -253,6 +219,7 @@ LFUCache.prototype.populateAllHashes = async function (
           dataObj[field] = typeName;
         } else dataObj[field] = readVal[field];
       } else {
+        // case where the field from the input query is an array of hashes, recursively invoke populateAllHashes
         dataObj[field] = await this.populateAllHashes(
           readVal[field],
           fields[field]
@@ -260,6 +227,9 @@ LFUCache.prototype.populateAllHashes = async function (
         if (dataObj[field] === undefined) return undefined;
       }
     }
-    return dataObj;
-  }
+    // acc is an array of response object for each hash
+    const resolvedProm = await Promise.resolve(acc);
+    resolvedProm.push(dataObj);
+    return resolvedProm;
+  }, []);
 };

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -21,28 +21,13 @@ export default function normalizeResult(queryObj, resultObj, deleteFlag) {
       //iterates thru the array of objects and stores the hash in the result object with 'DELETE' as value
       obj.forEach((ele) => {
         const mutationKeys = Object.keys(ele);
-        const id =
-          ele[mutationKeys[0]].id ||
-          ele[mutationKeys[0]].ID ||
-          ele[mutationKeys[0]]._id ||
-          ele[mutationKeys[0]]._ID ||
-          ele[mutationKeys[0]].Id ||
-          ele[mutationKeys[0]]._Id;
-        const hash = ele[mutationKeys[0]].__typename + '~' + id;
+        const hash = labelId(ele[mutationKeys[0]]);
         result[hash] = 'DELETED';
       });
     } else {
       //else stores the hash in the result object with the value 'DELETE'
       const mutationKeys = Object.keys(obj);
-
-      const id =
-        obj[mutationKeys[0]].id ||
-        obj[mutationKeys[0]].ID ||
-        obj[mutationKeys[0]]._id ||
-        obj[mutationKeys[0]]._ID ||
-        obj[mutationKeys[0]].Id ||
-        obj[mutationKeys[0]]._Id;
-      const hash = obj[mutationKeys[0]].__typename + '~' + id;
+      const hash = labelId(obj[mutationKeys[0]]);
       result[hash] = 'DELETED';
     }
   }
@@ -97,24 +82,16 @@ function createRootQuery(queryObjArr, resultObj) {
     const result = resultObj.data[alias] ?? resultObj.data[name];
     // iterate thru the array of current query response
     // and store the hash of that response in an array
-    
+
     if (Array.isArray(result)) {
       const arrOfHashes = [];
       result.forEach((obj) => {
-        const id = obj.id || obj.ID || obj._id || obj._ID || obj.Id || obj._Id;
-        arrOfHashes.push(obj.__typename + '~' + id);
+        arrOfHashes.push(labelId(obj));
       });
       //store the array of hashes associated with the queryHash
       output[queryHash] = arrOfHashes;
     } else {
-      const id =
-        result.id ||
-        result.ID ||
-        result._id ||
-        result._ID ||
-        result.Id ||
-        result._Id;
-      output[queryHash] = result.__typename + '~' + id;
+      output[queryHash] = [labelId(result)];
     }
   });
   return output;
@@ -122,10 +99,7 @@ function createRootQuery(queryObjArr, resultObj) {
 
 //returns a hash value pair of each response obj passed in
 function createHash(obj, output = {}) {
-  const id = obj.id || obj.ID || obj._id || obj._ID || obj.Id || obj._Id;
-  //create hash
-  const hash = obj.__typename + '~' + id;
-
+  const hash = labelId(obj);
   //if output doesnt have a key of hash create a new obj with that hash key
   if (!output[hash]) output[hash] = {};
   // iterate thru the fields in the current obj and check whether the current field
@@ -136,14 +110,7 @@ function createHash(obj, output = {}) {
     if (!Array.isArray(obj[field])) {
       //check whether current field is an object
       if (typeof obj[field] === 'object' && obj[field] !== null) {
-        const id =
-          obj[field].id ||
-          obj[field].ID ||
-          obj[field]._id ||
-          obj[field]._ID ||
-          obj[field].Id ||
-          obj[field]._Id;
-        output[hash][field] = obj[field].__typename + '~' + id;
+        output[hash][field] = labelId(obj[field]);
         output = createHash(obj[field], output);
       } else {
         output[hash][field] = obj[field];
@@ -155,8 +122,7 @@ function createHash(obj, output = {}) {
     else {
       output[hash][field] = [];
       obj[field].forEach((obj) => {
-        const id = obj.id || obj.ID || obj._id || obj._ID || obj.Id || obj._Id;
-        const arrayHash = obj.__typename + '~' + id;
+        const arrayHash = labelId(obj);
         output[hash][field].push(arrayHash);
         output = createHash(obj, output);
       });
@@ -164,4 +130,9 @@ function createHash(obj, output = {}) {
     }
   }
   return output;
+}
+
+function labelId(obj) {
+  const id = obj.id || obj.ID || obj._id || obj._ID || obj.Id || obj._Id;
+  return obj.__typename + '~' + id;
 }

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -97,7 +97,7 @@ function createRootQuery(queryObjArr, resultObj) {
     const result = resultObj.data[alias] ?? resultObj.data[name];
     // iterate thru the array of current query response
     // and store the hash of that response in an array
-
+    
     if (Array.isArray(result)) {
       const arrOfHashes = [];
       result.forEach((obj) => {

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -54,7 +54,6 @@ export async function ObsidianRouter<T>({
 
   // If using Redis caching, the following lines need to be uncommented.
   const cache = new Cache();
-  cache.insertIntoRedis();
 
   // clear redis cache when restarting the server
   cache.cacheClear();

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -23,6 +23,8 @@ export interface ObsidianRouterOptions<T> {
   usePlayground?: boolean;
   useCache?: boolean;
   redisPort?: number;
+  policy?: string;
+  maxmemory?: string;
 }
 
 export interface ResolversProps {
@@ -43,6 +45,8 @@ export async function ObsidianRouter<T>({
   usePlayground = false,
   useCache = true,
   redisPort = 6379,
+  policy,
+  maxmemory,
 }: ObsidianRouterOptions<T>): Promise<T> {
   redisPortExport = redisPort;
   const router = new Router();
@@ -57,6 +61,14 @@ export async function ObsidianRouter<T>({
 
   // clear redis cache when restarting the server
   cache.cacheClear();
+
+  // set redis configurations
+
+  if (policy || maxmemory) {
+    console.log('inside if');
+    cache.configSet('maxmemory-policy', policy);
+    cache.configSet('maxmemory', maxmemory);
+  }
 
   await router.post(path, async (ctx: any) => {
     var t0 = performance.now();
@@ -85,6 +97,7 @@ export async function ObsidianRouter<T>({
           }
         }
 
+        // if not in cache, it will fetch a new response from database
         const result = await (graphql as any)(
           schema,
           body.query,

--- a/test_files/READ_ME_TEST.md
+++ b/test_files/READ_ME_TEST.md
@@ -13,4 +13,3 @@ Additional Deno Testing Resources:
 
 1. Deno Testing Docs: https://deno.land/manual/testing
 2. Rhum Testing Docs: https://deno.land/x/rhum@v1.1.4
-d

--- a/test_files/rhum_test_files/readCache_test.ts
+++ b/test_files/rhum_test_files/readCache_test.ts
@@ -17,7 +17,7 @@ import { test } from '../test_variables/readCache_variables.ts';
 Rhum.testPlan('read method on Cache class', () => {
   Rhum.testSuite('read()', () => {
     Rhum.testCase(
-      'should return a graphql response object if all required values are found in the cache',
+      '\n *** \n readCache_test \n should return a graphql response object if all required values are found in the cache',
       async () => {
         const cache = new Cache(test.cache);
         const result = await cache.read(test.singularInputQuery);

--- a/test_files/rhum_test_files/readCache_test.ts
+++ b/test_files/rhum_test_files/readCache_test.ts
@@ -61,7 +61,7 @@ Rhum.testPlan('read method on Cache class', () => {
       async () => {
         const cache = new Cache(test.cache);
         const result = await cache.populateAllHashes(
-          'Actor~1',
+          ['Actor~1'],
           test.fieldsUndefined
         );
         Rhum.asserts.assertEquals(result, undefined);
@@ -72,14 +72,16 @@ Rhum.testPlan('read method on Cache class', () => {
       async () => {
         const cache = new Cache(test.cache);
         const result = await cache.populateAllHashes(
-          'Actor~1',
+          ['Actor~1'],
           test.fieldsComplete
         );
-        Rhum.asserts.assertEquals(result, {
-          __typename: 'Actor',
-          id: '1',
-          firstName: 'Harrison',
-        });
+        Rhum.asserts.assertEquals(result, [
+          {
+            __typename: 'Actor',
+            id: '1',
+            firstName: 'Harrison',
+          },
+        ]);
       }
     );
   });

--- a/test_files/rhum_test_files/serverCache_test.ts
+++ b/test_files/rhum_test_files/serverCache_test.ts
@@ -1,0 +1,61 @@
+/**
+ * NOTES:
+ * This file will test the read and write method on the Cache class functionality.
+ */
+
+import {Cache as Cache} from '../../src/CacheClassServer.js';
+import { Rhum } from 'https://deno.land/x/rhum@v1.1.4/mod.ts';
+import { test as testWrite} from '../test_variables/writeCache_variables.ts';
+import { test as testRead } from '../test_variables/readCache_variables.ts';
+import { connect } from 'https://deno.land/x/redis/mod.ts';
+
+// set up a redis sever
+let redis;
+const context = 'server';
+
+if (context === 'server') {
+  redis = await connect({
+    hostname: "localhost",
+    port: 6379,
+  });
+}
+
+
+Rhum.testPlan('Write to Cache class', () => {
+  Rhum.testSuite('write()', () => {
+    Rhum.testCase(
+      'Should write to redis cache',
+        async () => {
+          const cache = new Cache(testWrite.originalCache);
+          await cache.write(testWrite.queryStr, testWrite.respObj);
+          Rhum.asserts.assertEquals(cache.storage, testWrite.originalCache);
+        }
+      );
+      Rhum.testCase(
+        'should not overwrite the fields in the original cache with the new fields if the fields are not the same',
+        async () => {
+          const cache = new Cache(testWrite.originalCache);
+          await cache.write(testWrite.queryStrTwo, testWrite.respObj);
+          Rhum.asserts.assertEquals(testWrite.originalCache, cache.storage);
+        }
+      );   
+    });
+
+    Rhum.testSuite('read()', () => {
+      Rhum.testCase(
+        'should return a graphql response object if all required values are found in the cache',
+        async () => {
+            const cache = new Cache(testRead.cache);
+            const result = await cache.read(testRead.singularInputQuery);
+            Rhum.asserts.assertEquals(result, testRead.singularQueryResObj);
+        }
+      );
+    }); 
+
+});
+
+Rhum.run();
+
+
+
+

--- a/test_files/rhum_test_files/serverCache_test.ts
+++ b/test_files/rhum_test_files/serverCache_test.ts
@@ -3,9 +3,9 @@
  * This file will test the read and write method on the Cache class functionality.
  */
 
-import {Cache as Cache} from '../../src/CacheClassServer.js';
+import { Cache as Cache } from '../../src/CacheClassServer.js';
 import { Rhum } from 'https://deno.land/x/rhum@v1.1.4/mod.ts';
-import { test as testWrite} from '../test_variables/writeCache_variables.ts';
+import { test as testWrite } from '../test_variables/writeCache_variables.ts';
 import { test as testRead } from '../test_variables/readCache_variables.ts';
 import { connect } from 'https://deno.land/x/redis/mod.ts';
 
@@ -15,47 +15,38 @@ const context = 'server';
 
 if (context === 'server') {
   redis = await connect({
-    hostname: "localhost",
+    hostname: 'localhost',
     port: 6379,
   });
 }
 
-
 Rhum.testPlan('Write to Cache class', () => {
   Rhum.testSuite('write()', () => {
-    Rhum.testCase(
-      'Should write to redis cache',
-        async () => {
-          const cache = new Cache(testWrite.originalCache);
-          await cache.write(testWrite.queryStr, testWrite.respObj);
-          Rhum.asserts.assertEquals(cache.storage, testWrite.originalCache);
-        }
-      );
-      Rhum.testCase(
-        'should not overwrite the fields in the original cache with the new fields if the fields are not the same',
-        async () => {
-          const cache = new Cache(testWrite.originalCache);
-          await cache.write(testWrite.queryStrTwo, testWrite.respObj);
-          Rhum.asserts.assertEquals(testWrite.originalCache, cache.storage);
-        }
-      );   
+    Rhum.testCase('Should write to redis cache', async () => {
+      const cache = new Cache(testWrite.originalCache);
+      await cache.write(testWrite.queryStr, testWrite.respObj);
+      Rhum.asserts.assertEquals(cache.storage, testWrite.originalCache);
     });
+    Rhum.testCase(
+      'should not overwrite the fields in the original cache with the new fields if the fields are not the same',
+      async () => {
+        const cache = new Cache(testWrite.originalCache);
+        await cache.write(testWrite.queryStrTwo, testWrite.respObj);
+        Rhum.asserts.assertEquals(testWrite.originalCache, cache.storage);
+      }
+    );
+  });
 
-    Rhum.testSuite('read()', () => {
-      Rhum.testCase(
-        'should return a graphql response object if all required values are found in the cache',
-        async () => {
-            const cache = new Cache(testRead.cache);
-            const result = await cache.read(testRead.singularInputQuery);
-            Rhum.asserts.assertEquals(result, testRead.singularQueryResObj);
-        }
-      );
-    }); 
-
+  Rhum.testSuite('read()', () => {
+    Rhum.testCase(
+      '\n *** \n serverCache_test \nshould return a graphql response object if all required values are found in the cache',
+      async () => {
+        const cache = new Cache(testRead.cache);
+        const result = await cache.read(testRead.singularInputQuery);
+        Rhum.asserts.assertEquals(result, testRead.singularQueryResObj);
+      }
+    );
+  });
 });
 
 Rhum.run();
-
-
-
-

--- a/test_files/test_variables/normalize_variables.ts
+++ b/test_files/test_variables/normalize_variables.ts
@@ -161,8 +161,8 @@ export const test = {
   },
   resultObj1: {
     ROOT_QUERY: {
-      'movies(input:{genre:ACTION})': ['Movie~1', 'Movie~4'],//"hero(episode:EMPIRE)": ["Hero~1"]              OR      /"hero": ["Hero~1", "Hero~2"]  
-      actors: ['Actor~1', 'Actor~2', 'Actor~3', 'Actor~4', 'Actor~5'],//"hero(episode:JEDI)": ["Hero~2"]
+      'movies(input:{genre:ACTION})': ['Movie~1', 'Movie~4'], //"hero(episode:EMPIRE)": ["Hero~1"]              OR      /"hero": ["Hero~1", "Hero~2"]
+      actors: ['Actor~1', 'Actor~2', 'Actor~3', 'Actor~4', 'Actor~5'], //"hero(episode:JEDI)": ["Hero~2"]
     },
     'Movie~1': {
       id: '1',
@@ -306,56 +306,58 @@ export const test = {
       favHobby: 'climbing',
     },
   },
-  aliasTestQueryObj:{
+  aliasTestQueryObj: {
     queries: [
       {
         __typename: 'meta',
         name: 'hero',
         alias: 'empireHero',
         arguments: '(episode:EMPIRE)',
-        fields: { 
+        fields: {
           __typename: 'meta',
-          name: 'scalar', 
-          id: 'scalar'}
+          name: 'scalar',
+          id: 'scalar',
+        },
       },
       {
         __typename: 'meta',
         name: 'hero',
         alias: 'jediHero',
         arguments: '(episode:JEDI)',
-        fields: { 
+        fields: {
           __typename: 'meta',
-          name: 'scalar', 
-          id: 'scalar'}
-      }
-    ]
+          name: 'scalar',
+          id: 'scalar',
+        },
+      },
+    ],
   },
-  aliasTestResult:{
+  aliasTestResult: {
     data: {
       empireHero: {
         __typename: 'Hero',
-        id:'1',
-        name: 'Luke Skywalker'
+        id: '1',
+        name: 'Luke Skywalker',
       },
       jediHero: {
         __typename: 'Hero',
-        id:'2',
-        name: "R2-D2",
-      }
-    }
+        id: '2',
+        name: 'R2-D2',
+      },
+    },
   },
   aliasTestRootHash: {
-    "Hero~1": {
-      id: "1",
-      name: "Luke Skywalker",
+    'Hero~1': {
+      id: '1',
+      name: 'Luke Skywalker',
     },
-    "Hero~2": {
-      id: "2",
-      name: "R2-D2",
+    'Hero~2': {
+      id: '2',
+      name: 'R2-D2',
     },
     ROOT_QUERY: {
-      "hero(episode:EMPIRE)": "Hero~1",
-      "hero(episode:JEDI)": "Hero~2",
-    }
+      'hero(episode:EMPIRE)': ['Hero~1'],
+      'hero(episode:JEDI)': ['Hero~2'],
+    },
   },
 };

--- a/test_files/test_variables/readCache_variables.ts
+++ b/test_files/test_variables/readCache_variables.ts
@@ -90,11 +90,13 @@ export const test = {
   fieldsComplete: { __typename: 'meta', id: 'scalar', firstName: 'scalar' },
   singularQueryResObj: {
     data: {
-      actor: {
-        __typename: 'Actor',
-        id: '1',
-        firstName: 'Harrison',
-      },
+      actor: [
+        {
+          __typename: 'Actor',
+          id: '1',
+          firstName: 'Harrison',
+        },
+      ],
     },
   },
   multipleQueriesResObj: {
@@ -183,34 +185,33 @@ name
   }
 
 }`,
-aliasResObj:{
-  data: {
+  aliasResObj: {
+    data: {
       empireHero: {
-          __typename: "Hero",
-          id: 1,
-          name: "Luke Skywalker",
-
+        __typename: 'Hero',
+        id: 1,
+        name: 'Luke Skywalker',
       },
       jediHero: {
-          __typename: "Hero",
-          id: 2,
-          name: "R2-D2",
-      }
-  }
-},
+        __typename: 'Hero',
+        id: 2,
+        name: 'R2-D2',
+      },
+    },
+  },
   aliasCache: {
     ROOT_QUERY: {
-      'getHero(episode:"empire")': "Hero~1",
-      'getHero(episode:"jedi")': "Hero~2",
+      'getHero(episode:"empire")': 'Hero~1',
+      'getHero(episode:"jedi")': 'Hero~2',
     },
     ROOT_MUTATION: {},
-    "Hero~1": {
+    'Hero~1': {
       id: 1,
-      name: "Luke Skywalker",
+      name: 'Luke Skywalker',
     },
-    "Hero~2": {
+    'Hero~2': {
       id: 2,
-      name: "R2-D2",
+      name: 'R2-D2',
     },
   },
 };

--- a/test_files/test_variables/readCache_variables.ts
+++ b/test_files/test_variables/readCache_variables.ts
@@ -1,7 +1,7 @@
 export const test = {
   cache: {
     ROOT_QUERY: {
-      'actor(id:1)': 'Actor~1',
+      'actor(id:1)': ['Actor~1'],
       movies: ['Movie~1', 'Movie~2', 'Movie~3', 'Movie~4'],
       actors: ['Actor~1', 'Actor~2', 'Actor~3', 'Actor~4'],
       'movies(input:{genre:ACTION})': ['Movie~1', 'Movie~4', 'Movie~5'],

--- a/test_files/test_variables/readCache_variables.ts
+++ b/test_files/test_variables/readCache_variables.ts
@@ -187,22 +187,26 @@ name
 }`,
   aliasResObj: {
     data: {
-      empireHero: {
-        __typename: 'Hero',
-        id: 1,
-        name: 'Luke Skywalker',
-      },
-      jediHero: {
-        __typename: 'Hero',
-        id: 2,
-        name: 'R2-D2',
-      },
+      empireHero: [
+        {
+          __typename: 'Hero',
+          id: 1,
+          name: 'Luke Skywalker',
+        },
+      ],
+      jediHero: [
+        {
+          __typename: 'Hero',
+          id: 2,
+          name: 'R2-D2',
+        },
+      ],
     },
   },
   aliasCache: {
     ROOT_QUERY: {
-      'getHero(episode:"empire")': 'Hero~1',
-      'getHero(episode:"jedi")': 'Hero~2',
+      'getHero(episode:"empire")': ['Hero~1'],
+      'getHero(episode:"jedi")': ['Hero~2'],
     },
     ROOT_MUTATION: {},
     'Hero~1': {


### PR DESCRIPTION
# Checklist

- [ ] Bugfix
- [ ] New feature
- [X] Refactor

# Related Issue
Root Query objects with single hashes were treated differently than those with multiple hashes.
Normalize file had non-DRY functionality regarding hashing


# Solution
All Root Query objects contain arrays, even those with only a single hash.
labelId helper function was created to clean up code in accordance with DRY.
