### PR TITLE
Implemented DoS security module. Now queries and mutations have selectable nesting depth limit.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": true
+}

--- a/src/DoSSecurity.ts
+++ b/src/DoSSecurity.ts
@@ -21,7 +21,7 @@ export default function queryDepthLimiter(queryString: string, queryDepthLimit: 
    * @param {*} depth indicates current depth level
    * @returns boolean indicating whether query depth exceeds maximum depth
    */
-  const queryDepthCheck = (qryObj: queryObj, qryDepthLim: number, depth: number = 0): boolean | undefined => {
+  const queryDepthCheck = (qryObj: queryObj, qryDepthLim: number, depth: number = 0): boolean => {
     // Base case 1: check to see if depth exceeds limit, if so, return error (true means depth limit was exceeded)
     if (depth > qryDepthLim) return true;
     // Recursive case: Iterate through values of queryObj, and check if each value is an object,

--- a/src/DoSSecurity.ts
+++ b/src/DoSSecurity.ts
@@ -1,0 +1,55 @@
+import destructureQueries from './destructure.js';
+
+interface queryObj {
+  queries?: Array<object>,
+  mutations?: Array<object>,
+}
+/**
+ * Tests whether a queryString (string representation of query) exceeds the maximum nested depth levels (queryDephtLimit) allowable for the instance of obsidian
+ * @param {*} queryString the string representation of the graphql query
+ * @param {*} queryDepthLimit number representation of the maximum query depth limit.  Default 0 will return undefined. Root query doesn't count toward limit.
+ * @returns boolean indicating whether the query depth exceeded maximum allowed query depth
+ */
+export default function queryDepthExceeded(queryString: string, queryDepthLimit: number = 0): void {
+  const queryObj = destructureQueries(queryString) as queryObj;
+  // Make a subfunction called 'queryDepthCheck', params queryObj, queryDepthLimit, depth and returns boolean
+  /**
+   *Function that tests whether the query object debth exceeds maximum depth
+   * @param {*} qryObj an object representation of the query (after destructure)
+   * @param {*} qryDepthLim the maximum query depth
+   * @param {*} depth indicates current depth level
+   * @returns boolean indicating whether query depth exceeds maximum depth
+   */
+  const queryDepthCheck = (qryObj: queryObj, qryDepthLim: number, depth: number = 0): boolean => {
+    // check if queryObj has query or mutation root type, if so, call query depth check on each of its elements
+    if (Object.prototype.hasOwnProperty.call(qryObj, 'queries')) {
+      qryObj.queries?.forEach((element: object) => {
+        queryDepthCheck(element, queryDepthLimit);
+      });
+    }
+    if (Object.prototype.hasOwnProperty.call(qryObj, 'mutations')) {
+      qryObj.mutations?.forEach((element: object) => {
+        queryDepthCheck(element, queryDepthLimit);
+      });
+    }
+
+    // base case 1: check to see if depth exceeds limit, if so, return error (true => depth has been exceeded)
+    if (depth > qryDepthLim) return true;
+    // Iterate through values of queryObj, and check if it is an object,
+    for (let value = 0; value < Object.values(qryObj).length; value++) {
+      // if so return invoked QDC with depth+1
+      const currentValue = Object.values(qryObj)[value];
+      if (typeof currentValue === 'object') {
+        return queryDepthCheck(currentValue, qryDepthLim, depth + 1);
+      }
+    }
+    // base case 2: reach end of object keys iteration,return false - depth has not been exceeded
+    return false;
+  };
+  // Invoke QDC and if returns true return error, else return nothing
+  if (queryDepthCheck(queryObj, queryDepthLimit)) {
+    throw new Error(
+      'Security Error: Query depth exceeded maximum query depth limit'
+    );
+  }
+}

--- a/src/DoSSecurity.ts
+++ b/src/DoSSecurity.ts
@@ -7,7 +7,7 @@ interface queryObj {
 }
 
 /**
- * Tests whether a queryString (string representation of query) exceeds the maximum nested depth levels (queryDephtLimit) allowable for the instance of obsidian
+ * Tests whether a queryString (string representation of query) exceeds the maximum nested depth levels (queryDepthLimit) allowable for the instance of obsidian
  * @param {*} queryString the string representation of the graphql query
  * @param {*} queryDepthLimit number representation of the maximum query depth limit.  Default 0 will return undefined. Root query doesn't count toward limit.
  * @returns boolean indicating whether the query depth exceeded maximum allowed query depth

--- a/src/DoSSecurity.ts
+++ b/src/DoSSecurity.ts
@@ -1,18 +1,19 @@
 import destructureQueries from './destructure.js';
 
+// Interface representing shape of query object after destructuring
 interface queryObj {
   queries?: Array<object>,
   mutations?: Array<object>,
 }
+
 /**
  * Tests whether a queryString (string representation of query) exceeds the maximum nested depth levels (queryDephtLimit) allowable for the instance of obsidian
  * @param {*} queryString the string representation of the graphql query
  * @param {*} queryDepthLimit number representation of the maximum query depth limit.  Default 0 will return undefined. Root query doesn't count toward limit.
  * @returns boolean indicating whether the query depth exceeded maximum allowed query depth
  */
-export default function queryDepthExceeded(queryString: string, queryDepthLimit: number = 0): void {
+export default function queryDepthLimiter(queryString: string, queryDepthLimit: number = 0): void {
   const queryObj = destructureQueries(queryString) as queryObj;
-  // Make a subfunction called 'queryDepthCheck', params queryObj, queryDepthLimit, depth and returns boolean
   /**
    *Function that tests whether the query object debth exceeds maximum depth
    * @param {*} qryObj an object representation of the query (after destructure)
@@ -20,36 +21,39 @@ export default function queryDepthExceeded(queryString: string, queryDepthLimit:
    * @param {*} depth indicates current depth level
    * @returns boolean indicating whether query depth exceeds maximum depth
    */
-  const queryDepthCheck = (qryObj: queryObj, qryDepthLim: number, depth: number = 0): boolean => {
-    // check if queryObj has query or mutation root type, if so, call query depth check on each of its elements
-    if (Object.prototype.hasOwnProperty.call(qryObj, 'queries')) {
-      qryObj.queries?.forEach((element: object) => {
-        queryDepthCheck(element, queryDepthLimit);
-      });
-    }
-    if (Object.prototype.hasOwnProperty.call(qryObj, 'mutations')) {
-      qryObj.mutations?.forEach((element: object) => {
-        queryDepthCheck(element, queryDepthLimit);
-      });
-    }
-
-    // base case 1: check to see if depth exceeds limit, if so, return error (true => depth has been exceeded)
+  const queryDepthCheck = (qryObj: queryObj, qryDepthLim: number, depth: number = 0): boolean | undefined => {
+    // Base case 1: check to see if depth exceeds limit, if so, return error (true means depth limit was exceeded)
     if (depth > qryDepthLim) return true;
-    // Iterate through values of queryObj, and check if it is an object,
+    // Recursive case: Iterate through values of queryObj, and check if each value is an object,
     for (let value = 0; value < Object.values(qryObj).length; value++) {
-      // if so return invoked QDC with depth+1
+      // if the value is an object, return invokation queryDepthCheck on nested object and iterate depth
       const currentValue = Object.values(qryObj)[value];
       if (typeof currentValue === 'object') {
         return queryDepthCheck(currentValue, qryDepthLim, depth + 1);
-      }
-    }
-    // base case 2: reach end of object keys iteration,return false - depth has not been exceeded
+      };
+    };
+    // Base case 2: reach end of object keys iteration,return false - depth has not been exceeded
     return false;
   };
-  // Invoke QDC and if returns true return error, else return nothing
-  if (queryDepthCheck(queryObj, queryDepthLimit)) {
-    throw new Error(
-      'Security Error: Query depth exceeded maximum query depth limit'
-    );
-  }
+
+      // Check if queryObj has query or mutation root type, if so, call queryDepthCheck on each element, i.e. each query or mutation
+  if (queryObj.queries) {
+    for(let i = 0; i < queryObj.queries.length; i++) {
+      if(queryDepthCheck(queryObj.queries[i], queryDepthLimit)) {
+        throw new Error(
+          'Security Error: Query depth exceeded maximum query depth limit'
+        );
+      };
+    };
+  };
+  
+  if (queryObj.mutations){
+    for (let i = 0; i < queryObj.mutations.length; i++) {
+      if (queryDepthCheck(queryObj.mutations[i], queryDepthLimit)) {
+        throw new Error(
+          'Security Error: Query depth exceeded maximum mutation depth limit'
+        );
+      };
+    };
+  };
 }

--- a/src/destructure.js
+++ b/src/destructure.js
@@ -12,7 +12,7 @@
  *
  */
 // this function will destructure a query/mutation operation string into a query/mutation operation object
-export function destructureQueries(queryOperationStr) {
+export default function destructureQueries(queryOperationStr) {
   queryOperationStr = queryOperationStr.replace(/,/gm, '');
   // check if query has fragments
   if (queryOperationStr.indexOf('fragment') !== -1) {
@@ -209,8 +209,8 @@ export function destructureQueriesWithFragments(queryOperationStr) {
   const fragments = [];
   // helper function to separate fragment from query/mutation
   const separateFragments = (queryCopy) => {
-    let startFragIndex = queryCopy.indexOf('fragment');
-    let startFragCurly = queryCopy.indexOf('{', startFragIndex);
+    const startFragIndex = queryCopy.indexOf('fragment');
+    const startFragCurly = queryCopy.indexOf('{', startFragIndex);
     let endFragCurly;
     const stack = ['{'];
     const curlsAndParens = {
@@ -218,12 +218,12 @@ export function destructureQueriesWithFragments(queryOperationStr) {
       ')': '(',
     };
     for (let i = startFragCurly + 1; i < queryCopy.length; i++) {
-      let char = queryCopy[i];
+      const char = queryCopy[i];
       if (char === '{' || char === '(') {
         stack.push(char);
       }
       if (char === '}' || char === ')') {
-        let topOfStack = stack[stack.length - 1];
+        const topOfStack = stack[stack.length - 1];
         if (topOfStack === curlsAndParens[char]) stack.pop();
       }
       if (!stack[0]) {
@@ -232,10 +232,10 @@ export function destructureQueriesWithFragments(queryOperationStr) {
       }
     }
 
-    let fragment = queryCopy.slice(startFragIndex, endFragCurly + 1);
+    const fragment = queryCopy.slice(startFragIndex, endFragCurly + 1);
 
     fragments.push(fragment);
-    let newStr = queryCopy.replace(fragment, '');
+    const newStr = queryCopy.replace(fragment, '');
 
     return newStr;
   };
@@ -252,9 +252,9 @@ export function destructureQueriesWithFragments(queryOperationStr) {
   //! TODO: OPTIMIZE, SHOULD NOT NEED TO ITERATE THROUGH WHOLE QUERY STRING TO FIND THE ONE WORD NAME OF THE FRAGMENT. MAYBE WHILE STRING INDEX< INDEX OF '{' ?
   // store each fragment name with its corresponding fields in fragmentObj
   fragments.forEach((fragment) => {
-    let index = fragment.indexOf('{');
-    let words = fragment.split(' ');
-    let fragmentFields = fragment.slice(index + 1, fragment.length - 1);
+    const index = fragment.indexOf('{');
+    const words = fragment.split(' ');
+    const fragmentFields = fragment.slice(index + 1, fragment.length - 1);
 
     fragmentObj[words[1]] = fragmentFields;
   });
@@ -267,5 +267,3 @@ export function destructureQueriesWithFragments(queryOperationStr) {
 
   return queryCopy;
 }
-
-export default destructureQueries;

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -3,6 +3,7 @@ import { renderPlaygroundPage } from 'https://deno.land/x/oak_graphql@0.6.2/grap
 import { makeExecutableSchema } from 'https://deno.land/x/oak_graphql@0.6.2/graphql-tools/schema/makeExecutableSchema.ts';
 import LFUCache from './lfuBrowserCache.js';
 import { Cache } from './CacheClassServer.js';
+import queryDepthLimiter from './DoSSecurity.ts';
 
 interface Constructable<T> {
   new (...args: any): T & OakRouter;
@@ -25,6 +26,7 @@ export interface ObsidianRouterOptions<T> {
   redisPort?: number;
   policy?: string;
   maxmemory?: string;
+  maxQueryDepth?: number;
 }
 
 export interface ResolversProps {
@@ -47,6 +49,7 @@ export async function ObsidianRouter<T>({
   redisPort = 6379,
   policy,
   maxmemory,
+  maxQueryDepth = 0,
 }: ObsidianRouterOptions<T>): Promise<T> {
   redisPortExport = redisPort;
   const router = new Router();
@@ -65,7 +68,7 @@ export async function ObsidianRouter<T>({
   // set redis configurations
 
   if (policy || maxmemory) {
-    console.log('inside if');
+    // console.log('inside if');
     cache.configSet('maxmemory-policy', policy);
     cache.configSet('maxmemory', maxmemory);
   }
@@ -77,6 +80,11 @@ export async function ObsidianRouter<T>({
       try {
         const contextResult = context ? await context(ctx) : undefined;
         const body = await request.body().value;
+        
+        // If a securty limit is set for maxQueryDepth, invoke queryDepthLimiter 
+        // which throws error if query depth exceeds maximum
+        if (maxQueryDepth) queryDepthLimiter(body.query, maxQueryDepth);
+        
         // Variable to block the normalization of mutations //
         let toNormalize = true;
 
@@ -90,8 +98,8 @@ export async function ObsidianRouter<T>({
             var t1 = performance.now();
             console.log(
               'Obsidian retrieved data from cache and took ' +
-                (t1 - t0) +
-                ' milliseconds.'
+              (t1 - t0) +
+              ' milliseconds.',
             );
             return;
           }
@@ -104,7 +112,7 @@ export async function ObsidianRouter<T>({
           resolvers,
           contextResult,
           body.variables || undefined,
-          body.operationName || undefined
+          body.operationName || undefined,
         );
 
         // Send database response to client //
@@ -112,11 +120,12 @@ export async function ObsidianRouter<T>({
         response.body = result;
 
         // Normalize response and store in cache //
-        if (useCache && toNormalize && !result.errors)
+        if (useCache && toNormalize && !result.errors) {
           cache.write(body.query, result, false);
+        }
         var t1 = performance.now();
         console.log(
-          'Obsidian received new data and took ' + (t1 - t0) + ' milliseconds.'
+          'Obsidian received new data and took ' + (t1 - t0) + ' milliseconds.',
         );
         return;
       } catch (error) {
@@ -129,6 +138,7 @@ export async function ObsidianRouter<T>({
             },
           ],
         };
+        console.error('Error: ', error.message);
         return;
       }
     }

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -68,7 +68,6 @@ export async function ObsidianRouter<T>({
   // set redis configurations
 
   if (policy || maxmemory) {
-    // console.log('inside if');
     cache.configSet('maxmemory-policy', policy);
     cache.configSet('maxmemory', maxmemory);
   }

--- a/test_files/rhum_test_files/DoSSecurity_test.ts
+++ b/test_files/rhum_test_files/DoSSecurity_test.ts
@@ -5,18 +5,18 @@ import { test } from '../test_variables/DoSSecurity_variables.ts';
 
 Rhum.testPlan('DoSSecurity.ts', () => {
   Rhum.testSuite('Query depth limit NOT exceeded tests', () => {
-    Rhum.testCase('Test query depth with allowable depth 2', () => {
+    Rhum.testCase('Test query depth of 2 does not exceed allowable depth 2', () => {
       const results = queryDepthLimiter(test.DEPTH_2_QUERY, 2);
       Rhum.asserts.assertEquals(undefined, results);
     });
-    Rhum.testCase('Test mutation with allowable depth of 2', () => {
+    Rhum.testCase('Test mutation depth of 2 does not exceed allowable depth of 2', () => {
       const results = queryDepthLimiter(test.DEPTH_2_MUTATION, 2);
       Rhum.asserts.assertEquals(undefined, results);
     });
   });
   
   Rhum.testSuite('Query/mutation depth limit IS EXCEEDED tests', () => {
-    Rhum.testCase('Test query depth should be exceeded', () => {
+    Rhum.testCase('Test query depth 2 should exceed depth limit of 1', () => {
       Rhum.asserts.assertThrows(
         () => {
           queryDepthLimiter(test.DEPTH_2_QUERY, 1)
@@ -25,10 +25,42 @@ Rhum.testPlan('DoSSecurity.ts', () => {
         "Security Error: Query depth exceeded maximum query depth limit",
       )
     });
-    Rhum.testCase('Test mutation depth should be exceeded', () => {
+    Rhum.testCase('Test mutation depth 2 should exceed depth limit of 1', () => {
       Rhum.asserts.assertThrows(
         () => {
           queryDepthLimiter(test.DEPTH_2_MUTATION, 1)
+        },
+        Error,
+        "Security Error: Query depth exceeded maximum mutation depth limit",
+      )
+    });
+  });
+
+  Rhum.testSuite('Query depth limit NOT exceeded, multiple query tests', () => {
+    Rhum.testCase('Test multiple queries of depth 2 should not exceed allowable depth 2', () => {
+      const results = queryDepthLimiter(test.MULTIPLE_DEPTH_2_QUERY, 2);
+      Rhum.asserts.assertEquals(undefined, results);
+    });
+    Rhum.testCase('Test multiple mutations of depth 2 should not exceed allowable depth 2', () => {
+      const results = queryDepthLimiter(test.MULTIPLE_DEPTH_2_MUTATION, 2);
+      Rhum.asserts.assertEquals(undefined, results);
+    });
+  });
+
+  Rhum.testSuite('Multiple query/mutation depth limit IS EXCEEDED tests', () => {
+    Rhum.testCase('Test multiple query depth should be exceeded', () => {
+      Rhum.asserts.assertThrows(
+        () => {
+          queryDepthLimiter(test.MULTIPLE_DEPTH_2_QUERY, 1)
+        },
+        Error,
+        "Security Error: Query depth exceeded maximum query depth limit",
+      )
+    });
+    Rhum.testCase('Test multiple mutation depth should be exceeded', () => {
+      Rhum.asserts.assertThrows(
+        () => {
+          queryDepthLimiter(test.MULTIPLE_DEPTH_2_MUTATION, 1)
         },
         Error,
         "Security Error: Query depth exceeded maximum mutation depth limit",

--- a/test_files/rhum_test_files/DoSSecurity_test.ts
+++ b/test_files/rhum_test_files/DoSSecurity_test.ts
@@ -1,0 +1,40 @@
+import { Rhum } from 'https://deno.land/x/rhum@v1.1.4/mod.ts';
+import queryDepthLimiter from '../../src/DoSSecurity.ts';
+import { test } from '../test_variables/DoSSecurity_variables.ts';
+
+
+Rhum.testPlan('DoSSecurity.ts', () => {
+  Rhum.testSuite('Query depth limit NOT exceeded tests', () => {
+    Rhum.testCase('Test query depth with allowable depth 2', () => {
+      const results = queryDepthLimiter(test.DEPTH_2_QUERY, 10);
+      Rhum.asserts.assertEquals(undefined, results);
+    });
+    Rhum.testCase('Test mutation with allowable depth of 2', () => {
+      const results = queryDepthLimiter(test.DEPTH_2_MUTATION, 10);
+      Rhum.asserts.assertEquals(undefined, results);
+    });
+  });
+  
+  Rhum.testSuite('Query/mutation depth limit IS EXCEEDED tests', () => {
+    Rhum.testCase('Test query depth should be exceeded', () => {
+      Rhum.asserts.assertThrows(
+        () => {
+          queryDepthLimiter(test.DEPTH_2_QUERY, 1)
+        },
+        Error,
+        "Security Error: Query depth exceeded maximum query depth limit",
+      )
+    });
+    Rhum.testCase('Test mutation depth should be exceeded', () => {
+      Rhum.asserts.assertThrows(
+        () => {
+          queryDepthLimiter(test.DEPTH_2_MUTATION, 1)
+        },
+        Error,
+        "Security Error: Query depth exceeded maximum mutation depth limit",
+      )
+    });
+  });
+});
+
+Rhum.run();

--- a/test_files/rhum_test_files/DoSSecurity_test.ts
+++ b/test_files/rhum_test_files/DoSSecurity_test.ts
@@ -6,11 +6,11 @@ import { test } from '../test_variables/DoSSecurity_variables.ts';
 Rhum.testPlan('DoSSecurity.ts', () => {
   Rhum.testSuite('Query depth limit NOT exceeded tests', () => {
     Rhum.testCase('Test query depth with allowable depth 2', () => {
-      const results = queryDepthLimiter(test.DEPTH_2_QUERY, 10);
+      const results = queryDepthLimiter(test.DEPTH_2_QUERY, 2);
       Rhum.asserts.assertEquals(undefined, results);
     });
     Rhum.testCase('Test mutation with allowable depth of 2', () => {
-      const results = queryDepthLimiter(test.DEPTH_2_MUTATION, 10);
+      const results = queryDepthLimiter(test.DEPTH_2_MUTATION, 2);
       Rhum.asserts.assertEquals(undefined, results);
     });
   });

--- a/test_files/rhum_test_files/destructure_test.ts
+++ b/test_files/rhum_test_files/destructure_test.ts
@@ -1,6 +1,6 @@
 import { Rhum } from 'https://deno.land/x/rhum@v1.1.4/mod.ts';
-import {
-  destructureQueries,
+// import destructureQueries from '../../src/destructure.js';
+import destructureQueries, {
   findQueryStrings,
   createQueriesObj,
   splitUpQueryStr,

--- a/test_files/rhum_test_files/destructure_test.ts
+++ b/test_files/rhum_test_files/destructure_test.ts
@@ -1,5 +1,4 @@
 import { Rhum } from 'https://deno.land/x/rhum@v1.1.4/mod.ts';
-// import destructureQueries from '../../src/destructure.js';
 import destructureQueries, {
   findQueryStrings,
   createQueriesObj,

--- a/test_files/test_variables/DoSSecurity_variables.ts
+++ b/test_files/test_variables/DoSSecurity_variables.ts
@@ -27,4 +27,68 @@ export const test = {
       }
     }
   }`,
+
+  MULTIPLE_DEPTH_2_QUERY: `
+  query AllActionMovies {
+    movies(input: { genre: ACTION }) {
+      __typename
+      id
+      title
+      genre
+    },
+    movies(input: { genre: ACTION }) {
+      __typename
+      id
+      title
+      genre
+      actors {
+        id
+        firstName
+        lastName
+      }
+    },
+    movies(input: { genre: ACTION }) {
+      __typename
+      id
+      title
+      genre
+      actors {
+        id
+        firstName
+        lastName
+      }
+    }
+  }`,
+
+  MULTIPLE_DEPTH_2_MUTATION: `
+  mutation AllActionMovies {
+    movies(input: { genre: ACTION }) {
+      __typename
+      id
+      title
+      genre
+    },
+    movies(input: { genre: ACTION }) {
+      __typename
+      id
+      title
+      genre
+      actors {
+        id
+        firstName
+        lastName
+      }
+    },
+    movies(input: { genre: ACTION }) {
+      __typename
+      id
+      title
+      genre
+      actors {
+        id
+        firstName
+        lastName
+      }
+    }
+  }`,
 };

--- a/test_files/test_variables/DoSSecurity_variables.ts
+++ b/test_files/test_variables/DoSSecurity_variables.ts
@@ -1,0 +1,30 @@
+export const test = {
+  DEPTH_2_QUERY: `
+  query AllActionMovies {
+    movies(input: { genre: ACTION }) {
+      __typename
+      id
+      title
+      genre
+      actors {
+        id
+        firstName
+        lastName
+      }
+    }
+  }`,
+
+  DEPTH_2_MUTATION: `
+  mutation AllActionMoviesAndAllActors {
+    movies(input: { genre: ACTION }) {
+      id
+      title
+      genre
+      actors {
+        id
+        firstName
+        lastName
+      }
+    }
+  }`,
+};


### PR DESCRIPTION
Implemented Denial of Service attack security module enabling devs to set a maximum query nesting depth value, above which, queries will be rejected.

# Checklist

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

# Related Issue

Previously, Obsidian did not allow for instantiation of a GraphQL security strategy.  This feature easily allows for a developer-designated value to establish a maximum query depth limit to prevent a DoS attack of deeply-nested or recursive queries from overloading  the GraphQL runtime.  

# Solution

The solution was to provide a new DoSSecurity.ts module that allows developers to specify the maximum nested query depth upon initialization of the ObsidianRouter.  By default, the security feature is disabled with a value of 0.  If a value is specified, all GraphQL queries and mutations will be evaluated against the maximum query depth, and queries that exceed the maximum will not be routed to the GraphQL runtime, neutralizing a potential nested query DoS attack.

# Additional Info

This module was written in typescript.
