### PR TITLE
Refactor cache invalidation

### DIFF
--- a/src/Obsidian.ts
+++ b/src/Obsidian.ts
@@ -114,8 +114,9 @@ export async function ObsidianRouter<T>({
           body.operationName || undefined
         );
         const normalizedGQLResponse = normalizeObject(gqlResponse, customIdentifier);
-        if(isMutation(body)) { 
-          invalidateCache(normalizedGQLResponse);
+        if(isMutation(body)) {
+          const queryString = await request.body().value;
+          invalidateCache(normalizedGQLResponse, queryString.query);
         }
         else {
           const transformedGQLResponse = transformResponse(normalizedGQLResponse, customIdentifier);

--- a/src/Obsidian.ts
+++ b/src/Obsidian.ts
@@ -4,12 +4,10 @@ import { makeExecutableSchema } from 'https://deno.land/x/oak_graphql@0.6.2/grap
 import { Cache } from './quickCache.js';
 import queryDepthLimiter from './DoSSecurity.ts';
 import { restructure } from './restructure.ts';
-import { invalidateCache } from './invalidateCacheCheck.js';
 import { rebuildFromQuery } from './rebuild.js'
 import { normalizeObject } from './normalize.ts'
 import { transformResponse, detransformResponse } from './transformResponse.ts'
-import { isMutation } from './invalidateCacheCheck.js'
-// import LFUCache from './Browser/lfuBrowserCache.js';
+import { isMutation, invalidateCache } from './invalidateCacheCheck.ts'
 
 interface Constructable<T> {
   new(...args: any): T & OakRouter;

--- a/src/invalidateCacheCheck.js
+++ b/src/invalidateCacheCheck.js
@@ -12,7 +12,7 @@ const cache = new Cache();
  */
 export function isMutation(gqlQuery) {
   let isMutation = false;
-  let ast = gql(body.query);
+  let ast = gql(gqlQuery.query);
 
   const checkMutationVisitor = {
     OperationDefinition: (node) => {

--- a/src/invalidateCacheCheck.ts
+++ b/src/invalidateCacheCheck.ts
@@ -7,15 +7,16 @@ import { deepEqual } from "./utils.js";
 const cache = new Cache();
 
 /**
- * @param {object} gqlQuery - Object containing the query string
- * @return {boolean} Boolean indicating if it's a mutation query
+ * @param {any} gqlQuery - Object containing the query string
+ * @param {boolean} isMutation - Boolean indicating if it's a mutation query
+ * @return {boolean} isMutation
  */
-export function isMutation(gqlQuery) {
-  let isMutation = false;
-  let ast = gql(gqlQuery.query);
+export function isMutation(gqlQuery: { query: any; }): boolean {
+  let isMutation: boolean = false;
+  let ast: any = gql(gqlQuery.query);
 
-  const checkMutationVisitor = {
-    OperationDefinition: (node) => {
+  const checkMutationVisitor: object = {
+    OperationDefinition: (node: { operation: string; }) => {
       if (node.operation === "mutation") {
         isMutation = true;
       }
@@ -24,7 +25,7 @@ export function isMutation(gqlQuery) {
 
   // left this piece of code in case someone decides to build upon subscriptions, but for now obsidian doesn't do anything with subscriptions
   const subscriptionTunnelVisitor = {
-    OperationDefinition: (node) => {
+    OperationDefinition: (node: { operation: string; }) => {
       if (node.operation === "subscription") {
       }
     },
@@ -42,37 +43,37 @@ export function isMutation(gqlQuery) {
  * }
  * @param {string} queryString - raw mutation query.
  * Ex: 'mutation { addMovie(input: {title: "sdfsdg", releaseYear: 1234, genre: ACTION }) { __typename  id ti...'
- * @return {boolean} Boolean indicating if objectInQuestion is hashable or not
+ * @return {void}
  */
-export async function invalidateCache(normalizedMutation, queryString) {
+export async function invalidateCache(normalizedMutation: { [x: string]: object; }, queryString: string) {
   // isDelete flag is a safety net for delete mutations.
   // it's set to true if certain keywords such as 'delete' are found in the mutation query
   // Because we check if response object from delete mutation equals to cached object to determine if it's a delete mutation 
   // but there may be instances that the object is evicted from cache or never cached previously.
-  const deleteKeywords = ['delete', 'remove']
-  let isDelete = false;
+  const deleteKeywords: Array<string> = ['delete', 'remove'];
+  let isDelete: boolean = false;
+
   for (const keyword of deleteKeywords) {
     const regex = new RegExp(keyword);
     if (queryString.search(regex) !== -1) isDelete = true;
   }
 
-  let normalizedData;
-  let cachedVal;
+
+  let normalizedData: object;
+  let cachedVal: any;
+  
   for (const redisKey in normalizedMutation) {
     normalizedData = normalizedMutation[redisKey];
     cachedVal = await cache.cacheReadObject(redisKey);
 
-    // if response from mutation and cached response values are same then we assume it's a delete mutation
+    // if response objects from mutation and cache are deeply equal then we delete it from cache because it infers that a mutation is of type delete...
     if (cachedVal !== undefined && deepEqual(normalizedData, cachedVal) || isDelete) {
-      await cache.cacheDelete(redisKey)
-      return 'Cached object deleted due to mutation'
+      await cache.cacheDelete(redisKey);
     } else {
-      // otherwise it's an update or add mutation because mutation response doesn't match cached response values so we overwrite it
+      // otherwise it's an update or add mutation because response objects from mutation and cache don't match so we overwrite the existing cache value or write new data if cache at that key doesn't exist
       // Edge case: update is done without changing any values... cache will be deleted from redis because the response obj and cached obj will be equal
       // we put it in the backburner because it doesn't make our cache stale, we would just perform an extra operation to re-cache the missing value when a request comes in
-      await cache.cacheWriteObject(redisKey, normalizedData)
-      // extra check to delete the cached object if it contains certain keywords
-      return 'Cached object updated or added due to mutation'
+      await cache.cacheWriteObject(redisKey, normalizedData);
     }
   }
 }


### PR DESCRIPTION
# Checklist

- [ ] Bugfix
- [X] New feature
- [X] Refactor

# Related Issue

Refactored cache invalidation logic by adding JSDocs and converting the functions to TypeScript.
Added a new feature that makes delete mutation invalidation's logic more robust.

# Solution

The new feature checks the mutation's query string and sets the isDelete flag to true if it finds relevant keywords.
