### PR TITLE
removed conditional to always allow transformation

### DIFF
--- a/src/Obsidian.ts
+++ b/src/Obsidian.ts
@@ -86,7 +86,6 @@ export async function ObsidianRouter<T>({
       let body = await request.body().value;
       if (maxQueryDepth) queryDepthLimiter(body.query, maxQueryDepth); // If a securty limit is set for maxQueryDepth, invoke queryDepthLimiter, which throws error if query depth exceeds maximum
       body = { query: restructure(body) }; // Restructre gets rid of variables and fragments from the query
-      let cacheEvicted = false;
       let cacheQueryValue = await cache.read(body.query)
       // Is query in cache? 
       if (useCache && useQueryCache && cacheQueryValue) {
@@ -94,7 +93,6 @@ export async function ObsidianRouter<T>({
         if (!detransformedCacheQueryValue) {
           // cache was evicted if any partial cache is missing, which causes detransformResponse to return undefined
           cacheQueryValue = undefined;
-          cacheEvicted = true;
         } else {
           response.status = 200;
           response.body = detransformedCacheQueryValue;

--- a/src/Obsidian.ts
+++ b/src/Obsidian.ts
@@ -80,7 +80,7 @@ export async function ObsidianRouter<T>({
   await router.post(path, async (ctx: any) => {
     const t0 = performance.now();
     const { response, request } = ctx;
-    if (!request.hasBody) return; 
+    if (!request.hasBody) return;
     try {
       const contextResult = context ? await context(ctx) : undefined;
       let body = await request.body().value;
@@ -89,7 +89,7 @@ export async function ObsidianRouter<T>({
       let cacheEvicted = false;
       let cacheQueryValue = await cache.read(body.query)
       // Is query in cache? 
-      if (useCache && useQueryCache && cacheQueryValue){
+      if (useCache && useQueryCache && cacheQueryValue) {
         let detransformedCacheQueryValue = await detransformResponse(body.query, cacheQueryValue)
         if (!detransformedCacheQueryValue) {
           // cache was evicted if any partial cache is missing, which causes detransformResponse to return undefined
@@ -105,10 +105,10 @@ export async function ObsidianRouter<T>({
             ' milliseconds.', "background: #222; color: #00FF00"
           );
         }
-        
+
       };
       // If not in cache: 
-      if(useCache && useQueryCache && !cacheQueryValue){
+      if (useCache && useQueryCache && !cacheQueryValue) {
         const gqlResponse = await (graphql as any)(
           schema,
           body.query,
@@ -118,19 +118,16 @@ export async function ObsidianRouter<T>({
           body.operationName || undefined
         );
         const normalizedGQLResponse = normalizeObject(gqlResponse, customIdentifier);
-        if(isMutation(body)) {
+        if (isMutation(body)) {
           const queryString = await request.body().value;
           invalidateCache(normalizedGQLResponse, queryString.query);
         }
         // If read query: run query, normalize GQL response, transform GQL response, write to cache, and write pieces of normalized GQL response objects
         else {
-          if (!cacheEvicted) {
-            // if cache was not evicted, then this is the first time running this read query. Transform original GQL response to object of references:
-            const transformedGQLResponse = transformResponse(gqlResponse, customIdentifier);
-            await cache.write(body.query, transformedGQLResponse, false);
-          }
-          for(const key in normalizedGQLResponse){
-            await cache.cacheWriteObject(key, normalizedGQLResponse[key]); 
+          const transformedGQLResponse = transformResponse(gqlResponse, customIdentifier);
+          await cache.write(body.query, transformedGQLResponse, false);
+          for (const key in normalizedGQLResponse) {
+            await cache.cacheWriteObject(key, normalizedGQLResponse[key]);
           }
         }
         response.status = 200;

--- a/src/invalidateCacheCheck.ts
+++ b/src/invalidateCacheCheck.ts
@@ -84,7 +84,6 @@ export function isDelete(queryString: string) {
     const regex = new RegExp(keyword);
     // if query string contains any of the keywords in the deleteKeywords array we set the flag to true and break out of the loop
     if (queryString.search(regex) !== -1) {
-      console.log('setting isdelete to True!')
       isDeleteFlag = true;
       break;
     }


### PR DESCRIPTION
# Checklist

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

# Related Issue
When the router queried graphql due to some reference keys being evicted there was a conditional to skip transforming the querystring value in cache. While it was intended we didn't account for cases of delete mutation. It was causing querystring to have stale references that no longer exist in Redis and therefore always requesting data from graphql.

# Solution
In order for values to be retrieved from the cache on a 2nd request, the conditional was removed.

All tests passed
test result: ok. 57 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (842ms)
